### PR TITLE
#21 feat(ui): Implement basic layout for Best Start Times Panel

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,10 +24,31 @@
           WattWise
         </h1>
       </div>
-    </header>f
+    </header>
 
     <!-- Main content container -->
     <div class="container mx-auto p-4 pb-24 mt-20">
+      <!-- Best Start Times -->
+      <div class="mb-4 bg-gray-800 rounded-lg shadow p-4">
+        <h2 class="text-lg font-semibold mb-2 text-blue-400">
+          Best Start Times
+        </h2>
+        <div class="grid grid-cols-2 gap-2">
+          <!-- Today Card -->
+          <div class="bg-teal-700 rounded p-4">
+            <h3 class="text-sm font-medium">Today</h3>
+            <p class="text-2xl font-semibold">21:00</p>
+            <p class="text-sm">€0.42 / 1.2 kWh</p>
+          </div>
+          <!-- Tomorrow Card -->
+          <div class="bg-teal-800 rounded p-4">
+            <h3 class="text-sm font-medium">Tomorrow</h3>
+            <p class="text-2xl font-semibold">02:00</p>
+            <p class="text-sm">€0.38 / 1.2 kWh</p>
+          </div>
+        </div>
+      </div>
+      <!-- end best start time -->
     </div>
     <!-- end .container -->
 


### PR DESCRIPTION
This pull request implements the basic HTML structure and layout for the 'Best Start Times' panel.

The panel displays sections for 'Today' and 'Tomorrow' with placeholder data for the best start time and estimated cost/usage. Tailwind CSS has been used for initial styling.

Refs #21